### PR TITLE
Removal of dependency on Spring MVC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.n1global</groupId>
   <artifactId>async-couchdb-client</artifactId>
-  <version>0.62</version>
+  <version>0.62-1-SNAPSHOT</version>
   <name>async-couchdb-client</name>
   
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -36,18 +36,7 @@
       <artifactId>logback-classic</artifactId>
       <version>1.1.2</version>
     </dependency>
-    
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId> 
-      <version>4.2.0.RC1</version>    
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>  
-    </dependency>
-    
+
     <!-- For testing -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/com/n1global/acc/util/UrlBuilder.java
+++ b/src/main/java/com/n1global/acc/util/UrlBuilder.java
@@ -4,7 +4,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 
-import org.springframework.web.util.UriUtils;
 
 public class UrlBuilder {
     private String prefix;
@@ -17,7 +16,7 @@ public class UrlBuilder {
 
     public UrlBuilder addPathSegment(String pathSegment) {
         try {
-            prefix += "/" + UriUtils.encodePathSegment(pathSegment, "UTF-8");
+            prefix += "/" + URLEncoder.encode(pathSegment, "UTF-8");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Hi Vladimir

I've experimented with using you async-couchdb-client on a JBoss Wildfly application server. I've found one issue. The UrlBuilder class adds a dependency on spring-mvc, because off one line of code. It seems Spring MVC is only needed because of this one line of code. I will therefore suggest a rewrite and removal of the Spring MVC to keep the number of dependencies down. 

Best regards,
Jesper Tejlgaard
